### PR TITLE
CI: Update Lunr coding standard to 0.10.2

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -12,7 +12,7 @@ jobs:
       phpstan-level: 5
       allow-style-failures: false
       allow-phpstan-failures: false
-      codestyle-branch: '0.10.1'
+      codestyle-branch: '0.10.2'
       phpcs-whitelist: index.php.sample tests/phan.config.php tests/phpstan.autoload.inc.php tests/test.bootstrap.inc.php
       php-extensions: http, msgpack, uopz, xdebug, uuid
       stable-php-versions: '["8.1"]'


### PR DESCRIPTION
Unit tests are broken until the update for Lunr.Halo is complete