### PR TITLE
CI: Ignore phpunit vulnerability

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -6,8 +6,8 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   reuse:
-    uses: lunr-php/actions-templates/.github/workflows/reuse.yml@master
+    uses: lunr-php/actions-templates/.github/workflows/reuse.yml@9386864834d8121190171c18f44927a0492af392 # 0.11.0
   typos:
-    uses: lunr-php/actions-templates/.github/workflows/typos.yml@master
+    uses: lunr-php/actions-templates/.github/workflows/typos.yml@9386864834d8121190171c18f44927a0492af392 # 0.11.0
     with:
       config: tests/typos.toml

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 
 jobs:
   php-tests:
-    uses: lunr-php/actions-templates/.github/workflows/php-composer.yml@master
+    uses: lunr-php/actions-templates/.github/workflows/php-composer.yml@9386864834d8121190171c18f44927a0492af392 # 0.11.0
     with:
       phpstan-level: 5
       allow-style-failures: false

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,11 @@
     "ext-xdebug": "~3.1"
   },
   "config": {
+    "audit": {
+      "ignore": [
+        "PKSA-z3gr-8qht-p93v"
+      ]
+    },
     "optimize-autoloader": true
   },
   "autoload": {


### PR DESCRIPTION
We won't update to phpunit 9.6 in the stable branch, but the impact is fairly low.